### PR TITLE
Add/Correct prototypes for three functions that DICE C complained about

### DIFF
--- a/ContextTests.c
+++ b/ContextTests.c
@@ -4,7 +4,7 @@
 #include "ObjectMemory.h"
 #include "RealWordMemory.h"
 
-ObjectPointer stubMethodContext() {
+ObjectPointer stubMethodContext(void) {
   ObjectPointer methodContext = 0x1220, location = 0x0ffe, method = 0x200c, methodLocation = 0x0f00, literal = NilPointer;
   Word segment = (2 % HeapSegmentCount), instructionPointer = 0x1000, stackPointer = 0x1008;
 
@@ -23,7 +23,7 @@ ObjectPointer stubMethodContext() {
   return methodContext;
 }
 
-ObjectPointer stubBlockContext() {
+ObjectPointer stubBlockContext(void) {
   ObjectPointer context = 0x1222, location = 0x1ffc, homeMethod = stubMethodContext();
   Word segment = (2 % HeapSegmentCount), instructionPointer = 0x1004, stackPointer = 0x100c;
 
@@ -37,7 +37,7 @@ ObjectPointer stubBlockContext() {
   return context;
 }
 
-void activateContextWithThreeObjectsOnTheStack() {
+void activateContextWithThreeObjectsOnTheStack(void) {
   ObjectPointer object1 = NilPointer, object2 = OnePointer, object3 = TwoPointer, context = stubMethodContext();
   activeContext = context;
   Interpreter_fetchContextRegisters();

--- a/ObjectMemory_FreeList.h
+++ b/ObjectMemory_FreeList.h
@@ -49,7 +49,7 @@ void ObjectMemory_toFreePointerListAdd(ObjectPointer objectPointer);
  * Remove the most recent entry from the free pointer list and return it.
  * If the list is empty, then return nil.
  */
-ObjectPointer ObjectMemory_removeFromFreePointerList();
+ObjectPointer ObjectMemory_removeFromFreePointerList(void);
 
 /**
  * Return the head of the free chunk list of given size in the specified segment.


### PR DESCRIPTION
I still can't get DICE to *not crash* when it hits https://github.com/iamleeg/Amiga-Smalltalk/blob/master/ObjectMemory_FreeList.c#L6. but if I replace the modulus calculation with some random constant, I can at least get the building, and in fact at one point the tests all passed...  Along the way, it also complained about prototypes on these functions, so I added them.  I realise DICE is not high on the list of compilers we care about, but its an interesting challenge :-)