### PR TITLE
(Mostly) begin the primitive work

### DIFF
--- a/InterpreterMemoryTests.c
+++ b/InterpreterMemoryTests.c
@@ -97,7 +97,37 @@ Test(ExtractLowByteOfInteger) {
   Expect(lowByte == expected);
 }
 
+
+Test(PushAndPop) {
+	ObjectPointer anObject = 0x1234;
+	ObjectPointer aResult = 0;
+
+	activeContext = stubBlockContext();
+    Interpreter_fetchContextRegisters();
+    
+	Interpreter_push(anObject);
+	aResult = Interpreter_popStack();
+	Expect(anObject == aResult);
+}
+
+Test(PushAndPopInteger) {
+	short integerValue=1;
+	short actual = 0;
+	
+	activeContext = stubBlockContext();
+    Interpreter_fetchContextRegisters();
+
+	Interpreter_initPrimitive();
+	Interpreter_pushInteger(integerValue);
+	Expect(Interpreter_success() == YES);
+	actual = Interpreter_popInteger();
+	Expect(Interpreter_success() == YES);
+	Expect(integerValue == actual);
+}
+
 void InterpreterMemoryTests(struct TestResult *tr) {
+  RunTest(PushAndPop);
+  RunTest(PushAndPopInteger);
   RunTest(RoundTripIntegerThroughObjectMemory);
   RunTest(FailToStoreOutOfRangeInteger);
   RunTest(FailToFetchNonIntegerValue);

--- a/Interpreter_Error.c
+++ b/Interpreter_Error.c
@@ -7,6 +7,7 @@
 void Interpreter_error(char *message)
 {
   struct IntuiText body, postext, negtext;
+  BOOL response;
 
   body.IText = message;
   body.FrontPen = 0;
@@ -35,7 +36,7 @@ void Interpreter_error(char *message)
   negtext.ITextFont = NULL;
   negtext.NextText = NULL;
 
-  BOOL response = AutoRequest(NULL, &body, &postext, &negtext, 0, 0, 200, 80);
+  response = AutoRequest(NULL, &body, &postext, &negtext, 0, 0, 200, 80);
   if (response == FALSE) {
     exit(-1);
   }


### PR DESCRIPTION
Was going to split out `Interpreter_Primitives.c` from `Interpreter.c` but decided to conquer and then divide.

Along the way I fixed a variable declaration that VBCC complained about.  I'm also going to have to make my own vbcc friendly makefile now that just building *.c doesn't work on account of two `main` functions :-)

There's not much in here really but its the first bit of actual code outside of compiler fixes I have written so before I go any further I figured you should take a look at how I'm doing it.